### PR TITLE
Improve default matching convention

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -62,7 +62,7 @@
     "no-multiple-empty-lines": "error",
     "max-len": [
       "error",
-      120
+      140
     ],
     "max-lines": [
       "error",

--- a/dist/README.md
+++ b/dist/README.md
@@ -146,9 +146,8 @@ mockIStereo.Setup(s => s.SetStation(2), 'Station set to 2');
 
 ## Conventions
 
-***This convention will be replaced with opting out of the `exactSignatureMatch` param when calling `Setup` in version 2.0.0.***
+***This convention will be replaced by passing `false` to the `exactSignatureMatch` param when calling `Setup` in version 2.0.0.***
 
-You'll often want a mock to return the same response regardless of input parameters.  This library accommodates this through these conventions:
+You'll often want a mock to return the same response regardless of input parameters.  The following convention accommodates this:
 
-- If only one 'Setup' is made for a given method, the return value will be used for any combination of parameters (i.e. parameter values other than those specified in the setup).
-- If a method is called and no exact setup is available, the first 'Setup' will be returned.  In other words, if you have multiple setups for a method and this method is called using parameters that none of those setups accounted for, the return value will be the one specified in the first setup.
+- If a method is called and no exact setup is available, the first `Setup` called without overriding `exactSignatureMatch` to `true` will be used.

--- a/dist/README.md
+++ b/dist/README.md
@@ -19,7 +19,8 @@ class Mock<T>
 ```typescript
 Setup(
   member: (func: T) => any,
-  returns: any = null
+  returns: any = null,
+  exactSignatureMatch = false // will default to true and replace the signature matching convention as of v2.0.0.
 ): void
 ```
 ```typescript
@@ -144,6 +145,10 @@ mockIStereo.Setup(s => s.SetStation(2), 'Station set to 2');
 ```
 
 ## Conventions
+
+***This convention will be replaced with opting out of the `exactSignatureMatch` param when calling `Setup` in version 2.0.0.***
+
 You'll often want a mock to return the same response regardless of input parameters.  This library accommodates this through these conventions:
+
 - If only one 'Setup' is made for a given method, the return value will be used for any combination of parameters (i.e. parameter values other than those specified in the setup).
 - If a method is called and no exact setup is available, the first 'Setup' will be returned.  In other words, if you have multiple setups for a method and this method is called using parameters that none of those setups accounted for, the return value will be the one specified in the first setup.

--- a/dist/package.json
+++ b/dist/package.json
@@ -14,7 +14,7 @@
     "dependency injection"
   ],
   "license": "MIT",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Generic mocking library for TypeScript",
   "private": false,
   "main": "./public_api.js",

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -28,9 +28,9 @@ module.exports = function (config) {
       ]
     },
     karmaTypescriptConfig: {
-      tsconfig: "./tsconfig.json"
+      tsconfig: './tsconfig.json'
     }
-  })
-}
+  });
+};
 
-process.env.CHROME_BIN = require('puppeteer').executablePath()
+process.env.CHROME_BIN = require('puppeteer').executablePath();

--- a/src/Mock/Mock.ts
+++ b/src/Mock/Mock.ts
@@ -18,11 +18,8 @@ export class Mock<T> {
     if (SignatureService.MemberSignatureIsProperty(memberSignatureMap.signature)) {
       (this.object as any)[memberName] = this.getReturnsValueForProperty(memberSignatureMap);
     } else {
-
       (this.object as any)[memberName] = ((...args: any) => {
-        const returnFunction: any = this.getReturnsForFunction(memberSignatureMap, args, exactSignatureMatch);
-        return returnFunction ? returnFunction() :
-          (() => console.error('Unable to resolve setup function'))();
+        return this.getReturnsForFunction(memberSignatureMap, args, exactSignatureMatch)?.();
       });
     }
   }
@@ -57,22 +54,18 @@ export class Mock<T> {
     args: any,
     exactSignatureMatch: boolean
   ): Function | undefined {
-    let returnFunction: Function | undefined;
-    const existingMemberSignatureMap = this.memberSignatureMaps.find(s => s.signature === memberSignatureMap.signature);
+    const existingMemberSignatureMap = this.memberSignatureMaps.find(
+      s => s.signature === memberSignatureMap.signature);
+    const exactFunctionMap = existingMemberSignatureMap?.functionMaps.find(
+      m => JSON.stringify(m.state) === JSON.stringify(args));
+    const defaultFunctionMap = exactSignatureMatch ? undefined : existingMemberSignatureMap?.functionMaps[0];
 
-    const defaultFunctionMap = exactSignatureMatch ? undefined : memberSignatureMap.functionMaps[0];
-    if (existingMemberSignatureMap) {
-      const exactFunctionMap = existingMemberSignatureMap.functionMaps.find(
-        m => JSON.stringify(m.state) === JSON.stringify(args));
-      const functionMap = exactFunctionMap ? exactFunctionMap : defaultFunctionMap;
+    const functionMap = exactFunctionMap || defaultFunctionMap;
 
-      returnFunction = functionMap ? (() => {
-        functionMap.timesCalled++;
-        return functionMap.returns;
-      }) : undefined;
-    }
-
-    return returnFunction;
+    return functionMap ? (() => {
+      functionMap.timesCalled++;
+      return functionMap.returns;
+    }) : undefined;
   }
 
   private updateMemberSignatureMaps(memberSignatureMap: SignatureMap) {
@@ -99,23 +92,12 @@ export class Mock<T> {
     }
   }
 
-  private getFunctionMapFromSignatureMap(memberSignature: SignatureMap) {
-    let functionMap: FunctionMap | undefined;
-
+  private getFunctionMapFromSignatureMap(memberSignature: SignatureMap): FunctionMap | undefined {
     const existingMember = this.memberSignatureMaps.find(m => m.signature === memberSignature.signature);
     const functionMapToFind = memberSignature.functionMaps[0];
 
-    if (existingMember && functionMapToFind) {
-      const functionMapCount = existingMember.functionMaps ? existingMember.functionMaps.length : 0;
-      if (functionMapCount === 1) {
-        functionMap = existingMember.functionMaps[0];
-      } else {
-        functionMap = existingMember.functionMaps.find(
-          m => JSON.stringify(m.state) === JSON.stringify(functionMapToFind.state));
-      }
-    }
-
-    return functionMap;
+    return existingMember?.functionMaps.find(
+      m => JSON.stringify(m.state) === JSON.stringify(functionMapToFind.state)) ||
+      existingMember?.functionMaps[0];
   }
-
 }

--- a/src/Mock/Mock.ts
+++ b/src/Mock/Mock.ts
@@ -11,7 +11,7 @@ export class Mock<T> {
   }
 
   public Setup(member: (func: T) => any, returns: any = null, exactSignatureMatch = false): void {
-    const memberSignatureMap = SignatureService.GetMemberSignatureMap(member, returns);
+    const memberSignatureMap = SignatureService.GetMemberSignatureMap(member, returns, exactSignatureMatch);
     this.updateMemberSignatureMaps(memberSignatureMap);
 
     const memberName = SignatureService.GetMemberNameFromSignature(memberSignatureMap.signature);
@@ -58,7 +58,7 @@ export class Mock<T> {
       s => s.signature === memberSignatureMap.signature);
     const exactFunctionMap = existingMemberSignatureMap?.functionMaps.find(
       m => JSON.stringify(m.state) === JSON.stringify(args));
-    const defaultFunctionMap = exactSignatureMatch ? undefined : existingMemberSignatureMap?.functionMaps[0];
+    const defaultFunctionMap = exactSignatureMatch ? undefined : existingMemberSignatureMap?.functionMaps.find(m => m.default);
 
     const functionMap = exactFunctionMap || defaultFunctionMap;
 
@@ -98,6 +98,6 @@ export class Mock<T> {
 
     return existingMember?.functionMaps.find(
       m => JSON.stringify(m.state) === JSON.stringify(functionMapToFind.state)) ||
-      existingMember?.functionMaps[0];
+      existingMember?.functionMaps.find(m => m.default);
   }
 }

--- a/src/Mock/SignatureService.ts
+++ b/src/Mock/SignatureService.ts
@@ -3,7 +3,7 @@ import { Regex } from './Constants';
 
 export class SignatureService {
 
-  public static GetMemberSignatureMap(value: (obj: any) => any, returns?: any): SignatureMap {
+  public static GetMemberSignatureMap(value: (obj: any) => any, returns?: any, exactSignatureMatch = false): SignatureMap {
     let memberSignature = '';
 
     memberSignature =
@@ -15,7 +15,7 @@ export class SignatureService {
 
     return {
       signature: memberSignature,
-      functionMaps: [{ state: state, returns: returns ? returns : null, timesCalled: 0 }]
+      functionMaps: [{ default: !exactSignatureMatch, state: state, returns: returns ? returns : null, timesCalled: 0 }]
     };
   }
 

--- a/src/Mock/TypeLiterals.ts
+++ b/src/Mock/TypeLiterals.ts
@@ -1,4 +1,5 @@
 export type FunctionMap = {
+  default: boolean,
   state: string,
   returns: Function,
   timesCalled: number

--- a/src/Mock/module.ts
+++ b/src/Mock/module.ts
@@ -1,0 +1,2 @@
+export * from './Mock';
+export * from './Times';

--- a/src/Mock/tests/Mock.spec.ts
+++ b/src/Mock/tests/Mock.spec.ts
@@ -159,4 +159,22 @@ describe('Mock<T>', () => {
     expect(callCount).toEqual(0);
   });
 
+  it('should default to the first setup when exact match is not found', () => {
+    mockITestInterface.Setup(i => i.GetStringFromInt(1), 'one');
+    mockITestInterface.Setup(i => i.GetStringFromInt(3), 'three');
+    const classInstance = new DiTest(mockITestInterface.Object);
+
+    classInstance.GetStringFromInt(2);
+
+    mockITestInterface.Verify(i => i.GetStringFromInt(2), Times.Once);
+  });
+
+  it('should NOT default to the first setup when true was passed to setup exactSignatureMatch param', () => {
+    mockITestInterface.Setup(i => i.GetStringFromInt(1), 'one', true);
+    const classInstance = new DiTest(mockITestInterface.Object);
+
+    classInstance.GetStringFromInt(2);
+
+    mockITestInterface.Verify(i => i.GetStringFromInt(2), Times.Never);
+  });
 });

--- a/src/Mock/tests/Mock.spec.ts
+++ b/src/Mock/tests/Mock.spec.ts
@@ -169,12 +169,24 @@ describe('Mock<T>', () => {
     mockITestInterface.Verify(i => i.GetStringFromInt(2), Times.Once);
   });
 
-  it('should NOT default to the first setup when true was passed to setup exactSignatureMatch param', () => {
+  it('should NOT default to the first setup when true was passed to setup exactSignatureMatch param for all setups', () => {
     mockITestInterface.Setup(i => i.GetStringFromInt(1), 'one', true);
+    mockITestInterface.Setup(i => i.GetStringFromInt(3), 'three', true);
     const classInstance = new DiTest(mockITestInterface.Object);
 
     classInstance.GetStringFromInt(2);
 
     mockITestInterface.Verify(i => i.GetStringFromInt(2), Times.Never);
+  });
+
+  it('should default to the first setup where true was not passed to the exactSignatureMatch param', () => {
+    mockITestInterface.Setup(i => i.GetStringFromInt(1), 'one', true);
+    mockITestInterface.Setup(i => i.GetStringFromInt(3), 'three');
+    const classInstance = new DiTest(mockITestInterface.Object);
+
+    const actual = classInstance.GetStringFromInt(2);
+
+    expect(actual).toEqual('three');
+    mockITestInterface.Verify(i => i.GetStringFromInt(2), Times.Once);
   });
 });

--- a/src/Utility/EmitEventAtElement.ts
+++ b/src/Utility/EmitEventAtElement.ts
@@ -1,0 +1,10 @@
+/**
+ * Emit an event at a given element
+ * @param element
+ * @param eventType
+ */
+export function EmitEventAtElement(element: HTMLElement, eventType: string): void {
+  const event = document.createEvent('Event');
+  event.initEvent(eventType);
+  element.dispatchEvent(event);
+}

--- a/src/Utility/EmitKeyEventAtElement.ts
+++ b/src/Utility/EmitKeyEventAtElement.ts
@@ -1,0 +1,19 @@
+/**
+ * Emit a key event at a given element
+ * @param element
+ * @param key
+ * @param keyEvent
+ */
+export function EmitKeyEventAtElement(
+  element: HTMLInputElement,
+  key: string,
+  keyEvent: 'keydown' | 'keypress' | 'keyup' | 'input'
+): void {
+  const event = document.createEvent('Event') as any;
+
+  event['keyCode'] = key;
+  event['key'] = key;
+
+  event.initEvent(keyEvent);
+  element.dispatchEvent(event);
+}

--- a/src/Utility/Expect.ts
+++ b/src/Utility/Expect.ts
@@ -1,0 +1,26 @@
+/**
+ * Performs an asynchronous assertion, allowing up to one second to pass before failing
+ * @param selector A function that returns the subject of the assertion once it is expected to pass.
+ * @param assertion A function that is given the result of the selector function for normal jasmine assertions.
+ */
+export function Expect<T>(
+  selector: () => T,
+  assertion: (m: jasmine.Matchers<T>) => void,
+  interval = 0,
+  getTimeFunc = () => Date.now()
+): Promise<void> {
+  return new Promise(resolve => {
+    const startTime = getTimeFunc();
+    const timedOut = () => getTimeFunc() - startTime > 1000;
+    const execute = () => {
+      const selection = selector();
+      if (selection || timedOut()) {
+        assertion(expect(selection));
+        resolve();
+      } else {
+        setTimeout(() => execute(), interval);
+      }
+    };
+    execute();
+  });
+}

--- a/src/Utility/TestHelpers.ts
+++ b/src/Utility/TestHelpers.ts
@@ -1,3 +1,10 @@
+import { EmitEventAtElement } from './EmitEventAtElement';
+import { EmitKeyEventAtElement } from './EmitKeyEventAtElement';
+import { Expect } from './Expect';
+
+/**
+ * @deprecated This class will be removed in v2 - Import its functions directly as of 1.3.0
+ */
 export class TestHelpers {
   /**
    * Emit an event at a given element
@@ -5,9 +12,7 @@ export class TestHelpers {
    * @param eventType
    */
   public static EmitEventAtElement(element: HTMLElement, eventType: string): void {
-    const event = document.createEvent('Event');
-    event.initEvent(eventType);
-    element.dispatchEvent(event);
+    EmitEventAtElement(element, eventType);
   }
 
   /**
@@ -21,13 +26,7 @@ export class TestHelpers {
     key: string,
     keyEvent: 'keydown' | 'keypress' | 'keyup' | 'input'
   ): void {
-    const event = document.createEvent('Event') as any;
-
-    event['keyCode'] = key;
-    event['key'] = key;
-
-    event.initEvent(keyEvent);
-    element.dispatchEvent(event);
+    EmitKeyEventAtElement(element, key, keyEvent);
   }
 
   /**
@@ -68,19 +67,6 @@ export class TestHelpers {
     interval = 0,
     getTimeFunc = () => Date.now()
   ): Promise<void> {
-    return new Promise(resolve => {
-      const startTime = getTimeFunc();
-      const timedOut = () => getTimeFunc() - startTime > 1000;
-      const execute = () => {
-        const selection = selector();
-        if (selection || timedOut()) {
-          assertion(expect(selection));
-          resolve();
-        } else {
-          setTimeout(() => execute(), interval);
-        }
-      };
-      execute();
-    });
+    return Expect(selector, assertion, interval, getTimeFunc);
   }
 }

--- a/src/Utility/module.ts
+++ b/src/Utility/module.ts
@@ -1,0 +1,4 @@
+export * from './EmitEventAtElement';
+export * from './EmitKeyEventAtElement';
+export * from './Expect';
+export * from './TestHelpers';

--- a/src/public_api.ts
+++ b/src/public_api.ts
@@ -1,8 +1,2 @@
-/*
- * Public API Surface of tsmockit
- */
-
-export * from './Mock/Mock';
-export * from './Mock/Times';
-
-export * from './Utility/TestHelpers';
+export * from './Mock/module';
+export * from './Utility/module';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,60 +1,27 @@
 {
   "compilerOptions": {
-    /* Basic Options */
-    "target": "es5", /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
-    "module": "commonjs", /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
+    "target": "es5",
+    "module": "commonjs",
     "lib": [
       "dom",
       "es2015"
-    ], /* Specify library files to be included in the compilation. */
-    // "allowJs": true,                       /* Allow javascript files to be compiled. */
-    // "checkJs": true,                       /* Report errors in .js files. */
-    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
-    "declaration": true, /* Generates corresponding '.d.ts' file. */
-    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
-    "sourceMap": true, /* Generates corresponding '.map' file. */
-    // "outFile": "./",                       /* Concatenate and emit output to single file. */
-    "outDir": "dist", /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
-    // "removeComments": true,                /* Do not emit comments to output. */
-    // "noEmit": true,                        /* Do not emit outputs. */
-    "importHelpers": true, /* Import emit helpers from 'tslib'. */
-    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
-    /* Strict Type-Checking Options */
-    "strict": true, /* Enable all strict type-checking options. */
-    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,              /* Enable strict null checks. */
-    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
-    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
-    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
-    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
-    /* Additional Checks */
-    // "noUnusedLocals": true, /* Report errors on unused locals. */
-    // "noUnusedParameters": true, /* Report errors on unused parameters. */
-    "noImplicitReturns": true, /* Report error when not all code paths in function return a value. */
-    "noFallthroughCasesInSwitch": true, /* Report errors for fallthrough cases in switch statement. */
-    /* Module Resolution Options */
-    "moduleResolution": "node", /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
-    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
-    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    ],
+    "declaration": true,
+    "sourceMap": true,
+    "outDir": "dist",
+    "importHelpers": true,
+    "strict": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
     "types": [
       "jasmine",
       "node"
-    ], /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true, /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
-    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
-    /* Source Map Options */
-    // "sourceRoot": "./",                    /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-    // "mapRoot": "./",                       /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
-    "inlineSources": true, /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-    /* Experimental Options */
-    "experimentalDecorators": true, /* Enables experimental support for ES7 decorators. */
-    "emitDecoratorMetadata": true /* Enables experimental support for emitting type metadata for decorators. */
+    ],
+    "esModuleInterop": true,
+    "inlineSources": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "forceConsistentCasingInFileNames": true
   }
 }


### PR DESCRIPTION
Improves and clarifies the default matching convention

- A new parameter, "exactSignatureMatch" has been added to `Setup`
  - Default-ed to "false" now, will be default-ed to "true" in version 2.
- The convention will now be - the first setup called with "exactSignatureMatch" set to false, will be the default setup.
  - For clients unaware of the new param, there should be no practical difference.
- Verify will now respect the convention as well.
  - Previous to this change, Verify would check the count of the signature matches (of setups). 
- The new parameter will allow clients to opt out of the convention.
  - Currently this would mean, adding "true" for the new param to all setups.  In v2 this opt-out will switch to an opt-in. 
- Deprecate the TestHelpers class in favor of directly importing those functions.